### PR TITLE
Hotfix remove unnecessary check product attributes middleware

### DIFF
--- a/src/controllers/product_controller.js
+++ b/src/controllers/product_controller.js
@@ -33,7 +33,7 @@ async function createProduct(req, res) {
 async function addAttributeToProduct(req, res) {
     try {
 
-        const response = await productService.addAttributeToProduct(req.body);
+        const response = await productService.addAttributeToProduct(req.params.id, req.body);
 
         return res
                 .status(StatusCodes.CREATED)

--- a/src/middlewares/product_attribute_middleware.js
+++ b/src/middlewares/product_attribute_middleware.js
@@ -4,11 +4,6 @@ const BadRequest = require("../errors/bad_request_error");
 const errorResponse = require("../utils/error_response");
 
 function productAttributeValidator(req, res, next) {
-    if(!req.body.productId) {
-        return res
-                .status(StatusCodes.BAD_REQUEST)
-                .json(errorResponse(ReasonPhrases.BAD_REQUEST, new BadRequest("Product Id")))
-    }
 
     if(!req.body.attributeId) {
         return res

--- a/src/services/product_service.js
+++ b/src/services/product_service.js
@@ -61,10 +61,10 @@ class ProductService {
         
     }
 
-    async addAttributeToProduct(data) {
+    async addAttributeToProduct(id, data) {
         try {
 
-            const { id, attributeId, value } = data;
+            const { attributeId, value } = data;
 
             const response = await this.repository.addAttributeToProduct(id, attributeId, value);
             if(!response) {


### PR DESCRIPTION
Fixed **addAttributeToProduct** API by taking Product Id from req.params instead of from req.body redundantly.