### PR TITLE
Update signin API to return only user object in prod env

### DIFF
--- a/src/controllers/user_controller.js
+++ b/src/controllers/user_controller.js
@@ -37,9 +37,9 @@ async function signin(req, res) {
 
     try {
         
-        const response = await userService.signinUser(req.body);
+        const { user, token } = await userService.signinUser(req.body);
 
-        res.cookie('token', response, {
+        res.cookie('token', token, {
             httpOnly: true, 
             maxAge: 7 * 24 * 60 * 60 * 1000,
             secure: NODE_ENV == 'production'
@@ -51,7 +51,7 @@ async function signin(req, res) {
                     sucess: true,
                     error: {},
                     message: "Successfully signed in",
-                    data: (NODE_ENV == 'production') ? true : response
+                    data: (NODE_ENV == 'production') ? user : { user, token }
         });
 
     } catch(error) {

--- a/src/services/user_service.js
+++ b/src/services/user_service.js
@@ -68,11 +68,20 @@ class UserService {
             if((user.roleId != 1) && (!user.isRoleVerified)){
                 throw new ForbiddenError('Admin Panel', 'signin', 'Role unverified')
             }
-            return generateJWT({
+
+            const token = generateJWT({
                 email: user.email, 
                 id: user.id, 
                 roleId: user.roleId
             });
+
+            const userDetails = await this.getUser(user.id);
+
+            return {
+                user: userDetails,
+                token
+            };
+
         } catch(error) {
             console.log("UserService: ",error);
             if(error.name === "NotFoundError" || error.name === "UnauthorizedError" || error.name === "ForbiddenError") {


### PR DESCRIPTION
Update signin API: 

- In **production environment** only **User Object** would be returned and in **development environment** both **User Object and JWT Token** would be returned.